### PR TITLE
Fix: CUS-1729 GitHub actions for publishing

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,8 +1,6 @@
 name: Build and Test
 on:
   push:
-    branches-ignore:
-      - main
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -5,7 +5,7 @@ on:
 jobs:
   increment-version:
     permissions:
-      contents: write
+      id-token: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -18,10 +18,23 @@ jobs:
           node-version: '18.x'
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
+      - name: Get GH Token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.GH_RELEASE_APP_ID }}
+          private-key: ${{ secrets.GH_RELEASE_APP_PRIVATE_KEY }}
       - name: Increment version
+        uses: chainguard-dev/actions/setup-gitsign@main
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
+# Temporarily commenting out setting the git user.name and user.email to try the gitsign action which set these for signing commits.
+# https://www.chainguard.dev/unchained/keyless-git-commit-signing-with-gitsign-and-github-actions - not recommended for private repos
+#          git config user.name "datadogclientjsrepopush[bot]"
+#          git config user.email "161316041+datadogclientjsrepopush[bot]@users.noreply.github.com"
+          git remote set-url origin https://x-access-token/:${{ steps.app-token.outputs.token }}@github.com/${{ github.repository }}
           npm version ${{ github.event.release.tag_name }} -m "[ci skip] v%s"
           git tag -af ${{ github.event.release.tag_name }} -m "[ci skip] v%s"
           git push


### PR DESCRIPTION
## JIRA ticket link/s

- [CUS-1729](https://gymshark-web.atlassian.net/browse/CUS-1729)

## Summary of changes

1. Introducing an app that has permission to write to this repo and the app have been set to be allowed to push a commit to main since it's changing the version in the package.json. 
2. Trialing the ability to sign the commits in github actions
3. Always run build and test on every commit

## Additional Info


[CUS-1729]: https://gymshark-web.atlassian.net/browse/CUS-1729?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ