### PR TITLE
Fix: CUS-1729 fix export type

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -6,6 +6,6 @@ exports.logger = require('./logger');
 
 /**
  * Expose core metric relates classes and prototypes
- * @type {(function({}=): metrics.BufferedMetricsLogger)|{}}
+ * @type {function}
  */
 exports.metrics = require('./metrics');

--- a/lib/metics.test.js
+++ b/lib/metics.test.js
@@ -95,6 +95,8 @@ describe('Create Metrics', () => {
         assume(metrics).is.an('object');
         assume(metrics.prefix).equals('test.');
         assume(metrics.reporter.constructor.name).equals('NullReporter');
+
+        metrics.increment('test', 1)
     });
     test('should create metric client with sampling enabled and DD reporter', () => {
         const samplingKey = 'ed6fa6ad-b3cd-44f1-b105-2a017ad0d463'


### PR DESCRIPTION
## JIRA ticket link/s

- [CUS-1729](https://gymshark-web.atlassian.net/browse/CUS-1729)

## Summary of changes

1. Updating export type in comments as it was not exposing the functions of the `BufferedMetricsLogger` with the previous return type
2. Adding a call to increment a metric on a test to ensure they are exported correctly

## Additional Info



[CUS-1729]: https://gymshark-web.atlassian.net/browse/CUS-1729?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ