### PR TITLE
CUS-4628 - update codeowners for customer owned repos

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @gymshark/platform @gymshark/customer
+*     @gymshark/platform-customer @gymshark/platform-logistics @gymshark/platform-operations @gymshark/platform-product


### PR DESCRIPTION
## JIRA ticket link/s 

-   [CUS-4628](https://gymshark-web.atlassian.net/browse/CUS-4628)

## Summary of changes

1.  update CODEOWNERS file

[CUS-4628]: https://gymshark-web.atlassian.net/browse/CUS-4628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ